### PR TITLE
Remove force true from config.yml file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: cd ~ && ~/bin/plan.sh
       - run:
           name: apply master branch
-          command: cd ~ && ~/bin/apply.sh || true
+          command: cd ~ && ~/bin/apply.sh
       - run:
           name: switch symlink to branch
           command: |


### PR DESCRIPTION
`|| true` had to be added previously to the master branch build step due to an unresolvable failure occurring with building master branch. Now that the TF code and test has been modified, this can now be removed.