### PR TITLE
aws requires certs for cnames now. switching tests to not use cname

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -22,8 +22,6 @@ module "cloudfront_custom_origin" {
   https_port             = 443
   origin_protocol_policy = "https-only"
 
-  aliases = ["testdomain.${random_string.cloudfront_rstring.result}.example.com"]
-
   # default cache behavior
   allowed_methods  = ["GET", "HEAD"]
   cached_methods   = ["GET", "HEAD"]


### PR DESCRIPTION
##### Corresponding Issue(s):
https://jira.rax.io/browse/MPCSUPENG-298

##### Summary of change(s):
Removed CNAME from test as ssl cert needs to exist and match CNAME being used.


##### Reason for Change(s):

https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-cloudfront-enhances-the-security-for-adding-alternate-domain-names-to-a-distribution/

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
